### PR TITLE
Support for Python < 2.7

### DIFF
--- a/check_nvidiasmi.py
+++ b/check_nvidiasmi.py
@@ -13,6 +13,10 @@ class Utilization(nagiosplugin.Resource):
         self.nvidia_smi_xml_root = xml.etree.ElementTree.fromstring(nvidia_smi_proc_out)
 
     def probe(self):
+        if hasattr(self.nvidia_smi_xml_root, 'iter'):
+            nvidia_iter = self.nvidia_smi_xml_root.iter('gpu')
+        else:
+            nvidia_iter = self.nvidia_smi_xml_root.getiterator('gpu')
         for gpu in self.nvidia_smi_xml_root.iter('gpu'):
             utilization = gpu.find('utilization')
             gpuUtilization = float(utilization.find('gpu_util').text.strip(' %'))


### PR DESCRIPTION
Python 2.6.6 shipped with RHEL 6 does not support iter and displays the error:
UTILIZATION UNKNOWN: AttributeError: _ElementInterface instance has no attribute 'iter'
As a workaround "getiterator" will be used if the attribute "iter" is unkown

getiterator is deprecated since version 2.7 and was replaced by iter.

This patch adds support for Python < 2.7
